### PR TITLE
feat: accept pathlike inputs in filesystem helpers

### DIFF
--- a/src/conch/files.py
+++ b/src/conch/files.py
@@ -1,35 +1,45 @@
 import os
-from typing import Tuple, Optional, List, TypeAlias
+from typing import Tuple, Optional, List, TypeAlias, Union
+
+Pathish = Union[str, os.PathLike]
 
 ResultWithErrorStr: TypeAlias = Tuple[Optional[List[str]], Optional[str]]
 
-def load_file(filename: str) -> ResultWithErrorStr:
-    """Read a file and return its contents as a list of lines."""
+def load_file(filename: Pathish) -> ResultWithErrorStr:
+    """Read a file and return its contents as a list of lines.
+
+    ``filename`` may be a ``str`` or any ``os.PathLike`` object.  Using
+    ``os.fspath`` normalises the value so tests can freely pass ``Path``
+    objects without causing a ``TypeError`` on Windows or other
+    platforms.
+    """
+    path = os.fspath(filename)
     try:
-        with open(filename, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf-8") as f:
             content = f.read()
         return content.splitlines(), None
     except FileNotFoundError:
-        return None, f"Error: File '{filename}' not found"
+        return None, f"Error: File '{path}' not found"
     except PermissionError:
-        return None, f"Error: Permission denied accessing '{filename}'"
+        return None, f"Error: Permission denied accessing '{path}'"
     except UnicodeDecodeError:
-        return None, f"Error: Cannot decode '{filename}' as text (binary file?)"
+        return None, f"Error: Cannot decode '{path}' as text (binary file?)"
     except Exception as e:
-        return None, f"Error accessing '{filename}': {e}"
+        return None, f"Error accessing '{path}': {e}"
     return None, None  # Added to satisfy return type
 
 
-def load_folder(foldername: str) -> ResultWithErrorStr:
-    """List the contents of a folder, marking directories with a trailing slash."""
+def load_folder(foldername: Pathish) -> ResultWithErrorStr:
+    """List folder contents, marking directories with a trailing slash."""
+    path = os.fspath(foldername)
     try:
-        entries = os.listdir(foldername)
+        entries = os.listdir(path)
         entries.sort()
         if not entries:
             return ["(empty directory)"], None
         result = []
         for entry in entries:
-            entry_path = os.path.join(foldername, entry)
+            entry_path = os.path.join(path, entry)
             if os.path.isdir(entry_path):
                 result.append(f"{entry}/")
             else:
@@ -38,7 +48,7 @@ def load_folder(foldername: str) -> ResultWithErrorStr:
     except PermissionError:
         return None, "Error: Permission denied reading directory"
     except FileNotFoundError:
-        return None, f"Error: Directory '{foldername}' not found"
+        return None, f"Error: Directory '{path}' not found"
     except Exception as e:
-        return None, f"Error accessing directory '{foldername}': {e}"
+        return None, f"Error accessing directory '{path}': {e}"
     return None, None  # Added to satisfy return type


### PR DESCRIPTION
## Summary
- handle `Path` objects in `load_file` and `load_folder`
- normalize file system paths with `os.fspath`

## Testing
- `pytest` *(fails: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68a0ffaf4ffc8333ab2d311c823a969e