### PR TITLE
Add dot movement with arrow keys

### DIFF
--- a/tests/test_dot_movement.py
+++ b/tests/test_dot_movement.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from conch.tui import ConchTUI, LogView
+
+
+def test_arrow_keys_move_dot_and_update_title():
+    app = ConchTUI()
+    app.log_view = LogView()
+    app.input_mode = "sh"
+    app.log_view.write("line1")
+    app.log_view.write("line2")
+
+    app.action_move_down()
+
+    assert app.dot == (1, 0)
+    assert app.log_view.border_title == "Conch (2,1)"
+    line = app.log_view.lines[1]
+    assert getattr(line, "style", None) is not None
+
+    app.action_move_up()
+
+    assert app.dot == (0, 0)


### PR DESCRIPTION
## Summary
- Allow moving the dot with up/down arrow keys
- Highlight selected line in LogView and show dot in title
- Document dot movement and add regression test

## Testing
- `pytest -q` *(fails: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68a2e492907c8333826ba5fac14ea052