### PR TITLE
Add gf slash command to open file at cursor

### DIFF
--- a/tests/test_gf_command.py
+++ b/tests/test_gf_command.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from conch.tui import ConchTUI, LogView
+
+
+class DummyInput:
+    def __init__(self):
+        self.value = ""
+
+
+class DummyEvent:
+    def __init__(self, value: str):
+        self.value = value
+
+
+def test_gf_opens_file_from_listing(tmp_path):
+    d = tmp_path / "dir"
+    d.mkdir()
+    f = d / "file.txt"
+    f.write_text("hello")
+
+    app = ConchTUI()
+    app.log_view = LogView()
+    app.input = DummyInput()
+    app.input_mode = "sh"
+
+    app.log_view.append(f"# {d}")
+    app.log_view.append("file.txt")
+    app.log_view.append("§§§")
+    app.dot = (1, 0)
+
+    asyncio.run(app.on_input_submitted(DummyEvent("/gf")))
+
+    lines = [getattr(line, "text", str(line)) for line in app.log_view.lines]
+    assert lines[0] == f"# {f}"
+    assert lines[1] == "hello"


### PR DESCRIPTION
## Summary
- add `/gf` slash command to open file under cursor, falling back to base path from first line
- refactor file loading into new `_read_path` helper and document gf in help text
- cover `/gf` with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'textual')*


------
https://chatgpt.com/codex/tasks/task_e_68a45e2972088333a1e4b23587f32c78