### PR TITLE
Allow configurable CAS root

### DIFF
--- a/src/conch/commands.py
+++ b/src/conch/commands.py
@@ -54,7 +54,8 @@ def command_select(app, sel):
     return False
 
 def command_w(app):
-    cas_root = "e:/rsbohn/cas-01"
+    cas_root = os.environ.get("CONCH_CAS_ROOT", os.path.expanduser("~/.conch/cas"))
+    os.makedirs(cas_root, exist_ok=True)
     cas = CAS(cas_root)
     buffer_content = "\n".join([getattr(line, "text", str(line)) for line in app.log_view.lines])
     hash_value = cas.put(buffer_content)

--- a/tests/test_command_w.py
+++ b/tests/test_command_w.py
@@ -1,0 +1,48 @@
+import pytest
+import sys
+from types import SimpleNamespace
+
+sys.modules.setdefault("pyperclip", SimpleNamespace(paste=lambda: ""))
+
+from conch.commands import command_w
+
+class DummyLogView:
+    def __init__(self, lines=None):
+        self.lines = lines or []
+
+class DummyBusyIndicator:
+    def __init__(self):
+        self.message = None
+    def update(self, msg):
+        self.message = msg
+
+class DummyInput:
+    def __init__(self):
+        self.value = ""
+
+class DummyApp:
+    def __init__(self):
+        self.log_view = DummyLogView(["test content"])
+        self.busy_indicator = DummyBusyIndicator()
+        self.input = DummyInput()
+
+
+def test_command_w_uses_env_var(tmp_path, monkeypatch):
+    cas_path = tmp_path / "casdir"
+    monkeypatch.setenv("CONCH_CAS_ROOT", str(cas_path))
+    app = DummyApp()
+    command_w(app)
+    assert cas_path.exists()
+    assert (cas_path / "store").exists()
+    assert app.busy_indicator.message and app.busy_indicator.message.startswith("Saved: ")
+
+
+def test_command_w_defaults_to_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("CONCH_CAS_ROOT", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app = DummyApp()
+    command_w(app)
+    cas_path = tmp_path / ".conch" / "cas"
+    assert cas_path.exists()
+    assert (cas_path / "store").exists()
+    assert app.busy_indicator.message and app.busy_indicator.message.startswith("Saved: ")


### PR DESCRIPTION
## Summary
- allow overriding CAS storage root via `CONCH_CAS_ROOT` or default to `~/.conch/cas`
- ensure CAS root directory exists before use
- add tests covering environment variable and default behaviour for `/w` command

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `PYTHONPATH=src pytest tests/test_cas.py tests/test_command_w.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d09ac8d08333947d68deb882359c