### PR TITLE
Add basic Chasm PowerShell module

### DIFF
--- a/modules/Chasm/Chasm.psd1
+++ b/modules/Chasm/Chasm.psd1
@@ -1,0 +1,11 @@
+@{
+    RootModule = 'Chasm.psm1'
+    ModuleVersion = '0.1.0'
+    GUID = 'f3c8d37b-64d0-4cce-9a4e-87bddf9083c9'
+    Author = 'Contributors'
+    Description = 'Provides access to content-addressed storage.'
+    FunctionsToExport = @('Get-CASContent', 'Set-CASContent')
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+}

--- a/modules/Chasm/Chasm.psm1
+++ b/modules/Chasm/Chasm.psm1
@@ -1,0 +1,65 @@
+# Chasm.psm1 - Content Addressed Storage Module
+
+# Path to the directory holding CAS files
+$script:CasRoot = Join-Path $PSScriptRoot 'cas'
+if (-not (Test-Path $script:CasRoot)) {
+    New-Item -ItemType Directory -Path $script:CasRoot | Out-Null
+}
+
+function Store-ContentInCAS {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Content
+    )
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $hashBytes = $sha.ComputeHash($bytes)
+    $hash = ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLower()
+
+    $path = Join-Path $script:CasRoot $hash
+    Set-Content -Path $path -Value $Content -NoNewline
+    return $hash
+}
+
+function Get-ContentFromCAS {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Hash
+    )
+
+    $path = Join-Path $script:CasRoot $Hash
+    if (-not (Test-Path $path)) {
+        throw "Content with hash '$Hash' not found."
+    }
+
+    return Get-Content -Path $path -Raw
+}
+
+function Set-CASContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]$Content
+    )
+    process {
+        $hash = Store-ContentInCAS -Content $Content
+        Write-Output $hash
+    }
+}
+
+function Get-CASContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Hash
+    )
+    process {
+        $content = Get-ContentFromCAS -Hash $Hash
+        Write-Output $content
+    }
+}
+
+Export-ModuleMember -Function Get-CASContent, Set-CASContent


### PR DESCRIPTION
## Summary
- add Chasm PowerShell module to store and retrieve content in a simple file-based CAS
- include module manifest exporting Get-CASContent and Set-CASContent

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b8a0e69c83339fef692ff2aa15f6