### PR TITLE
Add basic Chasm PowerShell module

### DIFF
--- a/modules/Chasm/Chasm.psd1
+++ b/modules/Chasm/Chasm.psd1
@@ -1,0 +1,11 @@
+@{
+    RootModule = 'Chasm.psm1'
+    ModuleVersion = '0.1.0'
+    GUID = 'f3c8d37b-64d0-4cce-9a4e-87bddf9083c9'
+    Author = 'Contributors'
+    Description = 'Provides access to content-addressed storage.'
+    FunctionsToExport = @('Get-CASContent', 'Set-CASContent')
+    CmdletsToExport = @()
+    VariablesToExport = @()
+    AliasesToExport = @()
+}

--- a/modules/Chasm/Chasm.psm1
+++ b/modules/Chasm/Chasm.psm1
@@ -1,0 +1,99 @@
+# Chasm.psm1 - Content Addressed Storage Module
+
+function Get-CASRoot {
+    $root = $env:CONCH_CAS_ROOT
+    if (-not $root) {
+        $home = $env:HOME
+        if (-not $home) {
+            $home = [Environment]::GetFolderPath('UserProfile')
+        }
+        $root = Join-Path $home '.conch' 'cas'
+    }
+    if (-not (Test-Path $root)) {
+        New-Item -ItemType Directory -Path $root | Out-Null
+    }
+    $store = Join-Path $root 'store'
+    if (-not (Test-Path $store)) {
+        New-Item -ItemType Directory -Path $store | Out-Null
+    }
+    return $root
+}
+
+$script:CasRoot = Get-CASRoot
+$script:StoreDir = Join-Path $script:CasRoot 'store'
+
+function Get-CASPath {
+    param(
+        [Parameter(Mandatory=$true)][string]$Hash
+    )
+    $prefix = $Hash.Substring(0,2)
+    $dir = Join-Path $script:StoreDir $prefix
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir | Out-Null
+    }
+    return Join-Path $dir $Hash
+}
+
+function Store-ContentInCAS {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Content
+    )
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
+    if ($bytes.Length -gt 4MB) {
+        throw "Content too large (>4MB)"
+    }
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $hashBytes = $sha.ComputeHash($bytes)
+    $hash = ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLower()
+
+    $path = Get-CASPath -Hash $hash
+    if (-not (Test-Path $path)) {
+        $utf8 = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($path, $Content, $utf8)
+    }
+    return $hash
+}
+
+function Get-ContentFromCAS {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Hash
+    )
+
+    $path = Get-CASPath -Hash $Hash
+    if (-not (Test-Path $path)) {
+        return $null
+    }
+    $utf8 = New-Object System.Text.UTF8Encoding($false)
+    return [System.IO.File]::ReadAllText($path, $utf8)
+}
+
+function Set-CASContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]$Content
+    )
+    process {
+        $hash = Store-ContentInCAS -Content $Content
+        Write-Output $hash
+    }
+}
+
+function Get-CASContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Hash
+    )
+    process {
+        $content = Get-ContentFromCAS -Hash $Hash
+        Write-Output $content
+    }
+}
+
+Export-ModuleMember -Function Get-CASContent, Set-CASContent


### PR DESCRIPTION
## Summary
- add Chasm PowerShell module to store and retrieve content in a simple file-based CAS
- include module manifest exporting Get-CASContent and Set-CASContent
- align CAS layout with Python implementation for cross-language interoperability

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b8a0e69c83339fef692ff2aa15f6